### PR TITLE
Miri isn't all-caps

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ please create a PR or open an issue!
 |     Name     |                Repository               |                               Description                              |
 |:------------:|:---------------------------------------:|:----------------------------------------------------------------------:|
 | sanitizers | [built into the compiler](https://doc.rust-lang.org/unstable-book/compiler-flags/sanitizer.html) | Provides sanitizers for checking uninitialized memory access, uses of freed memory, memory leaks and data races between threads. |
-| MIRI  | https://github.com/rust-lang/miri             | An experimental interpreter for Rust's mid-level intermediate representation (MIR). It can run binaries and test suites of cargo projects and detect certain classes of undefined behavior, including Rust-specific ones that sanitizers cannot detect. |
+| Miri  | https://github.com/rust-lang/miri             | An experimental interpreter for Rust's mid-level intermediate representation (MIR). It can run binaries and test suites of cargo projects and detect certain classes of undefined behavior, including Rust-specific ones that sanitizers cannot detect. |
 
 Language-independent tools such as [Valgrind](https://www.valgrind.org/), [Dr. Memory](http://www.drmemory.org/), [libdiffuzz](https://github.com/Shnatsel/libdiffuzz) etc. also work.
 


### PR DESCRIPTION
In the Miri repo we usually spell it "Miri", let's be consistent here. :)